### PR TITLE
Print progress as JSON with --progress and --use-json-log

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -246,7 +246,11 @@ func Run(Retry bool, showStats bool, cmd *cobra.Command, f func() error) {
 		showStats = true
 	}
 	if ci.Progress {
-		stopStats = startProgress()
+		if ci.UseJSONLog {
+			stopStats = startProgress(printProgressJSON)
+		} else {
+			stopStats = startProgress(printProgress)
+		}
 	} else if showStats {
 		stopStats = StartStats()
 	}


### PR DESCRIPTION
Output example :

```json
{"bytes":110228,"checks":29,"deletedDirs":0,"deletes":0,"elapsedTime":2.9850246670000002,"errors":0,"eta":286436,"fatalError":false,"renames":0,"retryError":false,"speed":36896.19409968095,"totalBytes":10568517153,"totalChecks":29,"totalTransfers":10034,"transferTime":0,"transferring":[{"bytes":14159,"eta":null,"group":"global_stats","name":"deps/chrono-d364d2eba2f3d348.d","percentage":100,"size":14159,"speed":89062.03088364776,"speedAvg":0},{"bytes":0,"eta":null,"group":"global_stats","name":"deps/cipher-c41ec59e6e40b237.d","percentage":0,"size":2074,"speed":0,"speedAvg":0},{"bytes":0,"eta":null,"group":"global_stats","name":"deps/cipher-d650fe0cef64e9cc.d","percentage":0,"size":3338,"speed":0,"speedAvg":0},{"bytes":0,"eta":null,"group":"global_stats","name":"deps/cipher-d9f1405c2acc371b.d","percentage":0,"size":2074,"speed":0,"speedAvg":0}],"transfers":22}
```
